### PR TITLE
feat: Merge partial configs from multiple locations

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,24 +43,25 @@ The extension automatically recognizes and applies appropriate comment styles fo
 
 ### Configuration Priority (High to Low)
 
-The extension searches for `.auto-header.toml` in the following order and uses the **first one found**:
+The extension searches for `.auto-header.toml` in the following order and merges matching keys by priority, with earlier entries overriding later ones:
 
 1. **Project Root** (highest priority)
    - Path: `./.auto-header.toml` (in your project's root directory)
    - Use case: Project-specific headers with custom copyright, team info, etc.
 
-2. **Zed Config Directory**
-   - Linux/macOS: `~/.config/zed/auto-header.toml`
-   - Windows: `%APPDATA%\Zed\auto-header.toml`
+2. **Home Directory** 
+   - Path: `~/.auto-header.toml`
    - Use case: User-wide default settings for all projects
 
-3. **Home Directory** (lowest priority)
-   - Path: `~/.auto-header.toml`
+3. **Zed Config Directory** (lowest priority)
+   - macOS: `~/.config/zed/auto-header.toml`
+   - Windows: `%APPDATA%\Zed\auto-header.toml`
+   - Linux/FreeBSD: `$XDG_CONFIG_HOME/zed/auto-header.toml`
    - Use case: Fallback location, traditional dotfile approach
 
 **Recommendation**: 
 - Use **project root** for team projects with specific copyright/license requirements
-- Use **Zed config directory** for personal default settings across all projects
+- Use **Home Directory**/**Zed config directory** for personal default settings across all projects
 
 ### Basic Configuration Example
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -51,24 +51,25 @@
 
 ### 配置文件优先级（从高到低）
 
-扩展按以下顺序搜索 `.auto-header.toml` 并使用**第一个找到的文件**：
+扩展按以下顺序搜索 `.auto-header.toml`并按优先级合并相同key的配置值形成最终的使用配置：
 
 1. **项目根目录**（最高优先级）
    - 路径：`./.auto-header.toml`（项目根目录下）
    - 使用场景：项目特定的文件头，包含自定义版权、团队信息等
 
-2. **Zed 配置目录**
-   - Linux/macOS: `~/.config/zed/auto-header.toml`
-   - Windows: `%APPDATA%\Zed\auto-header.toml`
+2. **用户主目录**
+   - 路径：`~/.auto-header.toml`
    - 使用场景：用户级默认设置，应用于所有项目
 
-3. **用户主目录**（最低优先级）
-   - 路径：`~/.auto-header.toml`
+3. **Zed 配置目录**（最低优先级）
+   - macOS: `~/.config/zed/auto-header.toml`
+   - Windows: `%APPDATA%\Zed\auto-header.toml`
+   - Linux/FreeBSD: `$XDG_CONFIG_HOME/zed/auto-header.toml`
    - 使用场景：备用位置，传统的点文件方式
 
 **推荐用法**：
-- 团队项目使用**项目根目录**配置，设置特定的版权/许可信息
-- 个人项目使用 **Zed 配置目录**作为默认设置
+- **项目根目录**配置项目级信息，如设置特定的版权/许可信息
+- **用户主目录**或**Zed 配置目录**配置公共信息或默认设置，如用户、Email等信息
 
 ### 基础配置示例
 

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -4,7 +4,35 @@ use tower_lsp::{Client, LanguageServer, LspService, Server};
 use chrono::Local;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
-use std::path::Path;
+use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
+
+/// The resolved config directory, combining custom override or platform defaults.
+/// This is set once and cached for subsequent calls.
+/// On macOS, this is `~/.config/zed`.
+/// On Linux/FreeBSD, this is `$XDG_CONFIG_HOME/zed`.
+/// On Windows, this is `%APPDATA%\Zed`.
+static CONFIG_DIR: OnceLock<PathBuf> = OnceLock::new();
+
+/// Returns the path to the configuration directory used by Zed.
+fn config_dir() -> &'static PathBuf {
+    CONFIG_DIR.get_or_init(|| {
+        if cfg!(target_os = "windows") {
+            dirs::config_dir()
+                .expect("failed to determine RoamingAppData directory")
+                .join("Zed")
+        } else if cfg!(any(target_os = "linux", target_os = "freebsd")) {
+            if let Ok(flatpak_xdg_config) = std::env::var("FLATPAK_XDG_CONFIG_HOME") {
+                flatpak_xdg_config.into()
+            } else {
+                dirs::config_dir().expect("failed to determine XDG_CONFIG_HOME directory")
+            }
+            .join("zed")
+        } else {
+            dirs::home_dir().expect("failed to determine home directory").join(".config").join("zed")
+        }
+    })
+}
 
 /// Comment style for different programming languages
 #[derive(Debug, Clone)]
@@ -319,12 +347,7 @@ impl Config {
         }
         
         // 3. Platform-specific config directory fallback
-        // Windows: %APPDATA%\Zed\auto-header.toml
-        // macOS: ~/Library/Application Support/Zed/auto-header.toml
-        // Linux: ~/.config/zed/auto-header.toml
-        if let Some(config_dir) = dirs::config_dir() {
-            config_paths.push(config_dir.join("zed").join("auto-header.toml"));
-        }
+        config_paths.push(config_dir().join("auto-header.toml"));
         
         config_paths.iter().any(|path| !path.as_os_str().is_empty() && path.exists())
     }
@@ -343,8 +366,7 @@ impl Config {
         };
 
         // Platform config directory (lowest priority among file sources)
-        let platform_config = dirs::config_dir()
-            .and_then(|d| try_load(d.join("zed").join("auto-header.toml")))
+        let platform_config = try_load(config_dir().join("zed").join("auto-header.toml"))
             .unwrap_or_default();
 
         // Home directory (medium priority)

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -207,6 +207,101 @@ Copyright (c) {year} {copyright_holder}"#.to_string(),
     }
 }
 
+/// Partial versions of config structs for merging from multiple sources.
+/// All fields are Option so each config file only needs to specify what it overrides.
+#[derive(Debug, Clone, Deserialize, Default)]
+struct PartialAuthorConfig {
+    name: Option<String>,
+    email: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize, Default)]
+struct PartialProjectConfig {
+    name: Option<String>,
+    copyright_holder: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize, Default)]
+struct PartialHeaderConfig {
+    template: Option<String>,
+    by_extension: Option<HashMap<String, ExtensionHeaderConfig>>,
+}
+
+#[derive(Debug, Clone, Deserialize, Default)]
+struct PartialConfig {
+    author: Option<PartialAuthorConfig>,
+    project: Option<PartialProjectConfig>,
+    header: Option<PartialHeaderConfig>,
+}
+
+impl PartialConfig {
+    /// Merge two partial configs. `self` has higher priority than `lower`.
+    /// Fields present in `self` win; missing fields fall back to `lower`.
+    fn merge(self, lower: PartialConfig) -> PartialConfig {
+        PartialConfig {
+            author: match (self.author, lower.author) {
+                (Some(high), Some(low)) => Some(PartialAuthorConfig {
+                    name: high.name.or(low.name),
+                    email: high.email.or(low.email),
+                }),
+                (a, b) => a.or(b),
+            },
+            project: match (self.project, lower.project) {
+                (Some(high), Some(low)) => Some(PartialProjectConfig {
+                    name: high.name.or(low.name),
+                    copyright_holder: high.copyright_holder.or(low.copyright_holder),
+                }),
+                (a, b) => a.or(b),
+            },
+            header: match (self.header, lower.header) {
+                (Some(high), Some(low)) => Some(PartialHeaderConfig {
+                    template: high.template.or(low.template),
+                    by_extension: Some({
+                        // Start from lower priority map, then override with higher priority keys
+                        let mut merged = low.by_extension.unwrap_or_default();
+                        if let Some(ext) = high.by_extension {
+                            merged.extend(ext);
+                        }
+                        merged
+                    }),
+                }),
+                (a, b) => a.or(b),
+            },
+        }
+    }
+
+    /// Convert to a full `Config`, filling any missing fields with defaults.
+    fn into_config(self) -> Config {
+        let default = Config::default();
+        let author = self.author.unwrap_or_default();
+        let project = self.project.unwrap_or_default();
+        let header = self.header.unwrap_or_default();
+        Config {
+            author: AuthorConfig {
+                name: author.name.unwrap_or(default.author.name),
+                email: author.email.unwrap_or(default.author.email),
+            },
+            project: ProjectConfig {
+                name: project.name.unwrap_or(default.project.name),
+                copyright_holder: project
+                    .copyright_holder
+                    .unwrap_or(default.project.copyright_holder),
+            },
+            header: HeaderConfig {
+                template: header.template.unwrap_or(default.header.template),
+                by_extension: {
+                    // Default extension map first, then overlay whatever was configured
+                    let mut merged = default.header.by_extension;
+                    if let Some(ext) = header.by_extension {
+                        merged.extend(ext);
+                    }
+                    merged
+                },
+            },
+        }
+    }
+}
+
 impl Config {
     /// Check if any config file exists in the search paths
     /// Takes an optional workspace root directory to check for project-local config
@@ -218,7 +313,12 @@ impl Config {
             config_paths.push(root.join(".auto-header.toml"));
         }
         
-        // 2. Platform-specific config directory
+        // 2. Home directory: ~/.auto-header.toml
+        if let Some(home_dir) = dirs::home_dir() {
+            config_paths.push(home_dir.join(".auto-header.toml"));
+        }
+        
+        // 3. Platform-specific config directory fallback
         // Windows: %APPDATA%\Zed\auto-header.toml
         // macOS: ~/Library/Application Support/Zed/auto-header.toml
         // Linux: ~/.config/zed/auto-header.toml
@@ -226,46 +326,42 @@ impl Config {
             config_paths.push(config_dir.join("zed").join("auto-header.toml"));
         }
         
-        // 3. Home directory fallback: ~/.auto-header.toml
-        if let Some(home_dir) = dirs::home_dir() {
-            config_paths.push(home_dir.join(".auto-header.toml"));
-        }
-
         config_paths.iter().any(|path| !path.as_os_str().is_empty() && path.exists())
     }
 
-    /// Load config from multiple locations, preferring project-local config
+    /// Load and merge configs from all locations with explicit priority:
+    /// Project root > Home directory > Platform config > built-in default
+    ///
+    /// Each file is optional and only needs to specify the keys it wants to override.
     fn load_from_workspace(workspace_root: Option<&Path>) -> Self {
-        // Try to load config from multiple locations:
-        // 1. Project root: ./.auto-header.toml (if workspace_root provided)
-        // 2. Platform config: (see config_exists for platform-specific paths)
-        // 3. Home directory: ~/.auto-header.toml
-        
-        let mut config_paths = Vec::new();
-        
-        if let Some(root) = workspace_root {
-            config_paths.push(root.join(".auto-header.toml"));
-        }
-        
-        if let Some(config_dir) = dirs::config_dir() {
-            config_paths.push(config_dir.join("zed").join("auto-header.toml"));
-        }
-        if let Some(home_dir) = dirs::home_dir() {
-            config_paths.push(home_dir.join(".auto-header.toml"));
-        }
-
-        for path in config_paths {
-            if !path.as_os_str().is_empty() && path.exists() {
-                if let Ok(content) = std::fs::read_to_string(&path) {
-                    if let Ok(config) = toml::from_str::<Config>(&content) {
-                        return config;
-                    }
-                }
+        let try_load = |path: std::path::PathBuf| -> Option<PartialConfig> {
+            if path.as_os_str().is_empty() || !path.exists() {
+                return None;
             }
-        }
+            let content = std::fs::read_to_string(&path).ok()?;
+            toml::from_str::<PartialConfig>(&content).ok()
+        };
 
-        // Return default config if no config file found
-        Config::default()
+        // Platform config directory (lowest priority among file sources)
+        let platform_config = dirs::config_dir()
+            .and_then(|d| try_load(d.join("zed").join("auto-header.toml")))
+            .unwrap_or_default();
+
+        // Home directory (medium priority)
+        let home_config = dirs::home_dir()
+            .and_then(|d| try_load(d.join(".auto-header.toml")))
+            .unwrap_or_default();
+
+        // Project root (highest priority)
+        let project_config = workspace_root
+            .and_then(|r| try_load(r.join(".auto-header.toml")))
+            .unwrap_or_default();
+
+        // Merge: project > home > platform, then fill gaps with built-in default
+        project_config
+            .merge(home_config)
+            .merge(platform_config)
+            .into_config()
     }
 
     fn load() -> Self {
@@ -519,6 +615,365 @@ impl LanguageServer for AutoHeaderServer {
                     .log_message(MessageType::INFO, format!("Header inserted for {}", uri.path()))
                     .await;
             }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    /// Build an `ExtensionHeaderConfig` map from a slice of (ext, template) pairs.
+    fn ext_map(entries: &[(&str, &str)]) -> HashMap<String, ExtensionHeaderConfig> {
+        entries
+            .iter()
+            .map(|(k, v)| {
+                (
+                    k.to_string(),
+                    ExtensionHeaderConfig {
+                        template: v.to_string(),
+                    },
+                )
+            })
+            .collect()
+    }
+
+    /// Convenience builder: only populate the fields that are `Some`.
+    fn make_partial(
+        author_name: Option<&str>,
+        author_email: Option<&str>,
+        project_name: Option<&str>,
+        copyright_holder: Option<&str>,
+        header_template: Option<&str>,
+        by_extension: Option<HashMap<String, ExtensionHeaderConfig>>,
+    ) -> PartialConfig {
+        let has_author = author_name.is_some() || author_email.is_some();
+        let has_project = project_name.is_some() || copyright_holder.is_some();
+        let has_header = header_template.is_some() || by_extension.is_some();
+        PartialConfig {
+            author: has_author.then(|| PartialAuthorConfig {
+                name: author_name.map(str::to_string),
+                email: author_email.map(str::to_string),
+            }),
+            project: has_project.then(|| PartialProjectConfig {
+                name: project_name.map(str::to_string),
+                copyright_holder: copyright_holder.map(str::to_string),
+            }),
+            header: has_header.then(|| PartialHeaderConfig {
+                template: header_template.map(str::to_string),
+                by_extension,
+            }),
+        }
+    }
+
+    // ── into_config ───────────────────────────────────────────────────────────
+
+    /// An all-empty PartialConfig must produce the exact built-in defaults.
+    #[test]
+    fn empty_partial_yields_defaults() {
+        let config = PartialConfig::default().into_config();
+        let default = Config::default();
+        assert_eq!(config.author.name, default.author.name);
+        assert_eq!(config.author.email, default.author.email);
+        assert_eq!(config.project.name, default.project.name);
+        assert_eq!(
+            config.project.copyright_holder,
+            default.project.copyright_holder
+        );
+        assert_eq!(config.header.template, default.header.template);
+        assert_eq!(
+            config.header.by_extension.len(),
+            default.header.by_extension.len()
+        );
+    }
+
+    /// A single overridden field should use the given value; all other fields default.
+    #[test]
+    fn single_field_override_rest_are_defaults() {
+        let partial = PartialConfig {
+            author: Some(PartialAuthorConfig {
+                name: Some("Alice".to_string()),
+                email: None,
+            }),
+            ..Default::default()
+        };
+        let config = partial.into_config();
+        let default = Config::default();
+        assert_eq!(config.author.name, "Alice");
+        assert_eq!(config.author.email, default.author.email);
+        assert_eq!(config.project.name, default.project.name);
+        assert_eq!(config.header.template, default.header.template);
+    }
+
+    // ── merge: two-source priority ────────────────────────────────────────────
+
+    /// When both configs set the same key, `self` (higher priority) wins.
+    #[test]
+    fn project_wins_over_home_same_key() {
+        let home = make_partial(
+            Some("HomeUser"),
+            Some("home@example.com"),
+            None,
+            None,
+            None,
+            None,
+        );
+        let project = make_partial(Some("ProjectUser"), None, None, None, None, None);
+        let config = project.merge(home).into_config();
+        assert_eq!(config.author.name, "ProjectUser"); // project wins
+        assert_eq!(config.author.email, "home@example.com"); // home fills the gap
+    }
+
+    /// When only the lower-priority config sets a key, that value is used.
+    #[test]
+    fn missing_in_high_falls_through_to_low() {
+        let platform = make_partial(
+            Some("PlatformUser"),
+            Some("platform@example.com"),
+            None,
+            None,
+            None,
+            None,
+        );
+        let home = make_partial(Some("HomeUser"), None, None, None, None, None);
+        let config = home.merge(platform).into_config();
+        assert_eq!(config.author.name, "HomeUser"); // home wins
+        assert_eq!(config.author.email, "platform@example.com"); // falls through to platform
+    }
+
+    /// When neither config sets a field, the built-in default is used.
+    #[test]
+    fn missing_everywhere_uses_default() {
+        // Only author.name is set across all sources; everything else should be default.
+        let project = make_partial(Some("OnlyName"), None, None, None, None, None);
+        let config = project
+            .merge(PartialConfig::default())
+            .merge(PartialConfig::default())
+            .into_config();
+        let default = Config::default();
+        assert_eq!(config.author.name, "OnlyName");
+        assert_eq!(config.author.email, default.author.email);
+        assert_eq!(config.project.name, default.project.name);
+        assert_eq!(config.header.template, default.header.template);
+    }
+
+    // ── merge: three-source priority chain ────────────────────────────────────
+
+    /// Full three-way merge: each field comes from a different source to verify
+    /// the complete project > home > platform priority chain.
+    #[test]
+    fn three_way_merge_each_field_from_correct_source() {
+        let platform = make_partial(
+            Some("PlatformUser"),
+            Some("platform@corp.com"),
+            Some("PlatformApp"),
+            Some("Platform Corp"),
+            Some("platform template"),
+            None,
+        );
+        let home = make_partial(
+            Some("HomeUser"), // overrides platform author.name
+            None,
+            Some("HomeApp"), // overrides platform project.name
+            None,
+            None, // header.template: not set → falls to platform
+            None,
+        );
+        let project = make_partial(
+            None, // author.name: not set → falls to home
+            None,
+            None,                     // project.name: not set → falls to home
+            Some("My Startup"),       // overrides both home and platform
+            Some("project template"), // overrides both home and platform
+            None,
+        );
+
+        let config = project.merge(home).merge(platform).into_config();
+
+        assert_eq!(config.author.name, "HomeUser"); // home > platform
+        assert_eq!(config.author.email, "platform@corp.com"); // only in platform
+        assert_eq!(config.project.name, "HomeApp"); // home > platform
+        assert_eq!(config.project.copyright_holder, "My Startup"); // project wins
+        assert_eq!(config.header.template, "project template"); // project wins
+    }
+
+    // ── merge: by_extension HashMap ───────────────────────────────────────────
+
+    /// Higher-priority keys override lower-priority ones; unique keys from every
+    /// source are all preserved in the final map.
+    #[test]
+    fn by_extension_merge_preserves_unique_keys_from_all_sources() {
+        let platform = make_partial(
+            None,
+            None,
+            None,
+            None,
+            None,
+            Some(ext_map(&[("rs", "platform rs"), ("py", "platform py")])),
+        );
+        let home = make_partial(
+            None,
+            None,
+            None,
+            None,
+            None,
+            Some(ext_map(&[("rs", "home rs"), ("go", "home go")])),
+        );
+        let project = make_partial(
+            None,
+            None,
+            None,
+            None,
+            None,
+            Some(ext_map(&[("rs", "project rs")])),
+        );
+
+        let config = project.merge(home).merge(platform).into_config();
+        let by_ext = &config.header.by_extension;
+
+        assert_eq!(by_ext["rs"].template, "project rs"); // project wins
+        assert_eq!(by_ext["go"].template, "home go"); // home unique key preserved
+        assert_eq!(by_ext["py"].template, "platform py"); // platform unique key preserved
+    }
+
+    /// When only home and platform set the same extension key, home wins.
+    #[test]
+    fn by_extension_home_wins_over_platform() {
+        let platform = make_partial(
+            None,
+            None,
+            None,
+            None,
+            None,
+            Some(ext_map(&[("ts", "platform ts")])),
+        );
+        let home = make_partial(
+            None,
+            None,
+            None,
+            None,
+            None,
+            Some(ext_map(&[("ts", "home ts")])),
+        );
+
+        let config = PartialConfig::default()
+            .merge(home)
+            .merge(platform)
+            .into_config();
+
+        assert_eq!(config.header.by_extension["ts"].template, "home ts");
+    }
+
+    // ── TOML deserialization ──────────────────────────────────────────────────
+
+    /// A TOML file with only a subset of fields must parse into a PartialConfig
+    /// where only those fields are Some and the rest are None.
+    #[test]
+    fn toml_partial_parse_only_author_name() {
+        let toml_str = r#"
+[author]
+name = "TOML User"
+"#;
+        let partial: PartialConfig = toml::from_str(toml_str).unwrap();
+        let author = partial.author.as_ref().unwrap();
+        assert_eq!(author.name, Some("TOML User".to_string()));
+        assert!(author.email.is_none());
+        assert!(partial.project.is_none());
+        assert!(partial.header.is_none());
+    }
+
+    /// A TOML file with no content at all must deserialize as an all-None PartialConfig.
+    #[test]
+    fn toml_empty_string_yields_default_partial() {
+        let partial: PartialConfig = toml::from_str("").unwrap();
+        assert!(partial.author.is_none());
+        assert!(partial.project.is_none());
+        assert!(partial.header.is_none());
+    }
+
+    // ── End-to-end TOML three-way merge ───────────────────────────────────────
+
+    /// Simulate reading three real TOML config files and verify the final
+    /// merged Config reflects the correct priority for every field.
+    #[test]
+    fn toml_three_way_merge_end_to_end() {
+        let platform_toml = r#"
+[author]
+name = "Platform"
+email = "platform@corp.com"
+
+[project]
+name = "PlatformApp"
+copyright_holder = "Platform Corp"
+
+[header]
+template = "platform template"
+"#;
+        let home_toml = r#"
+[author]
+name = "HomeUser"
+
+[header]
+template = "home template"
+"#;
+        let project_toml = r#"
+[project]
+copyright_holder = "My Startup"
+"#;
+
+        let platform: PartialConfig = toml::from_str(platform_toml).unwrap();
+        let home: PartialConfig = toml::from_str(home_toml).unwrap();
+        let project: PartialConfig = toml::from_str(project_toml).unwrap();
+
+        let config = project.merge(home).merge(platform).into_config();
+
+        // author.name: project=None, home=Some → "HomeUser"
+        assert_eq!(config.author.name, "HomeUser");
+        // author.email: project=None, home=None, platform=Some → "platform@corp.com"
+        assert_eq!(config.author.email, "platform@corp.com");
+        // project.name: project=None, home=None, platform=Some → "PlatformApp"
+        assert_eq!(config.project.name, "PlatformApp");
+        // project.copyright_holder: project=Some → "My Startup"
+        assert_eq!(config.project.copyright_holder, "My Startup");
+        // header.template: project=None, home=Some → "home template"
+        assert_eq!(config.header.template, "home template");
+    }
+
+    /// Simulate TOML configs that include by_extension, verifying key-level
+    /// priority inside the merged map.
+    #[test]
+    fn toml_by_extension_three_way_merge() {
+        let platform_toml = r#"
+[header]
+template = "default"
+
+[header.by_extension]
+rs = { template = "Rust (platform)" }
+py = { template = "Python (platform)" }
+"#;
+        let home_toml = r#"
+[header.by_extension]
+rs = { template = "Rust (home)" }
+go = { template = "Go (home)" }
+"#;
+        let project_toml = r#"
+[header.by_extension]
+rs = { template = "Rust (project)" }
+"#;
+
+        let platform: PartialConfig = toml::from_str(platform_toml).unwrap();
+        let home: PartialConfig = toml::from_str(home_toml).unwrap();
+        let project: PartialConfig = toml::from_str(project_toml).unwrap();
+
+        let config = project.merge(home).merge(platform).into_config();
+        let by_ext = &config.header.by_extension;
+
+        assert_eq!(by_ext["rs"].template, "Rust (project)"); // project wins
+        assert_eq!(by_ext["go"].template, "Go (home)"); // home unique key
+        assert_eq!(by_ext["py"].template, "Python (platform)"); // platform unique key
+                                                                // header.template only set in platform, should survive the merge
+        assert_eq!(config.header.template, "default");
     }
 }
 


### PR DESCRIPTION
Add Partial* config structs and merging logic. load_from_workspace now loads optional partial TOML from project, home, and platform paths, merges
them with priority project > home > platform, and fills missing fields from built-in defaults so config files can override only selected keys.